### PR TITLE
Remove reexports and use latest rust-netlink crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ description = "netlink xfrm packet types for IPsec"
 anyhow = "1.0.39"
 byteorder = "1.4.2"
 libc= "0.2.86"
-netlink-packet-core = { version = "0.4.2" }
-netlink-packet-utils = { version = "0.5.1" }
+netlink-packet-core = { version = "0.5.0" }
+netlink-packet-utils = { version = "0.5.2" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/src/address.rs
+++ b/src/address.rs
@@ -20,7 +20,7 @@ buffer!(AddressBuffer(XFRM_ADDRESS_LEN) {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<AddressBuffer<&T>> for Address {
     fn parse(buf: &AddressBuffer<&T>) -> Result<Self, DecodeError> {
         let mut addr_payload: [u8; XFRM_ADDRESS_LEN] = [0; XFRM_ADDRESS_LEN];
-        addr_payload.clone_from_slice(&buf.addr());
+        addr_payload.clone_from_slice(buf.addr());
         Ok(Address { addr: addr_payload })
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -39,7 +39,7 @@ pub const XFRMA_ALG_CRYPT: u16 = 2; /* struct xfrm_algo */
 pub const XFRMA_ALG_COMP: u16 = 3; /* struct xfrm_algo */
 pub const XFRMA_ENCAP: u16 = 4; /* struct xfrm_algo + struct xfrm_encap_tmpl */
 pub const XFRMA_TMPL: u16 = 5; /* 1 or more struct xfrm_user_tmpl */
-pub const XFRMA_SA: u16 = 6; /* struct xfrm_usersa_info  */
+pub const XFRMA_SA: u16 = 6; /* struct xfrm_usersa_info */
 pub const XFRMA_POLICY: u16 = 7; /* struct xfrm_userpolicy_info */
 pub const XFRMA_SEC_CTX: u16 = 8; /* struct xfrm_sec_ctx */
 pub const XFRMA_LTIME_VAL: u16 = 9; /* struct xfrm_lifetime_cur */
@@ -48,7 +48,7 @@ pub const XFRMA_REPLAY_THRESH: u16 = 11; /* __u32 */
 pub const XFRMA_ETIMER_THRESH: u16 = 12; /* __u32 */
 pub const XFRMA_SRCADDR: u16 = 13; /* xfrm_address_t */
 pub const XFRMA_COADDR: u16 = 14; /* xfrm_address_t */
-pub const XFRMA_LASTUSED: u16 = 15; /* unsigned long  */
+pub const XFRMA_LASTUSED: u16 = 15; /* unsigned long */
 pub const XFRMA_POLICY_TYPE: u16 = 16; /* struct xfrm_userpolicy_type */
 pub const XFRMA_MIGRATE: u16 = 17; /* struct xfrm_user_migrate */
 pub const XFRMA_ALG_AEAD: u16 = 18; /* struct xfrm_algo_aead */
@@ -135,7 +135,7 @@ pub const IPPROTO_ESP: u8 = libc::IPPROTO_ESP as u8; //  50
 pub const IPPROTO_AH: u8 = libc::IPPROTO_AH as u8; //  51
 pub const IPPROTO_DSTOPTS: u8 = libc::IPPROTO_DSTOPTS as u8; //  60
 pub const IPPROTO_COMP: u8 = libc::IPPROTO_COMP as u8; // 108
-pub const IPSEC_PROTO_ANY: u8 = 255 as u8;
+pub const IPSEC_PROTO_ANY: u8 = 255_u8;
 
 // ==========================================
 // XFRM Mode
@@ -186,7 +186,7 @@ pub const XFRM_SC_ALG_SELINUX: u8 = 1;
 // Async Event flags
 // ==========================================
 pub const XFRM_AE_UNSPEC: u32 = 0;
-pub const XFRM_AE_RTHR: u32 = 1; /* replay threshold*/
+pub const XFRM_AE_RTHR: u32 = 1; /* replay threshold */
 pub const XFRM_AE_RVAL: u32 = 2; /* replay value */
 pub const XFRM_AE_LVAL: u32 = 4; /* lifetime value */
 pub const XFRM_AE_ETHR: u32 = 8; /* expiry timer threshold */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-pub use netlink_packet_core::{
-    ErrorMessage, NetlinkBuffer, NetlinkHeader, NetlinkMessage, NetlinkPayload,
-};
-pub(crate) use netlink_packet_core::{
-    NetlinkDeserializable, NetlinkSerializable,
-};
-
 pub mod address;
 pub use address::*;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -17,10 +17,12 @@ use crate::{
         FlushMessage as StateFlushMessage, GetDumpMessage, GetSadInfoMessage,
         ModifyMessage as StateModifyMessage, NewSadInfoMessage,
     },
-    NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
     XfrmBuffer,
 };
 
+use netlink_packet_core::{
+    NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
+};
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/nlas/alg.rs
+++ b/src/nlas/alg.rs
@@ -28,7 +28,7 @@ buffer!(AlgBuffer(XFRM_ALG_HEADER_LEN) {
 impl<T: AsRef<[u8]> + ?Sized> Parseable<AlgBuffer<&T>> for Alg {
     fn parse(buf: &AlgBuffer<&T>) -> Result<Self, DecodeError> {
         let mut alg_name: [u8; XFRM_ALG_NAME_LEN] = [0; XFRM_ALG_NAME_LEN];
-        alg_name.clone_from_slice(&buf.alg_name());
+        alg_name.clone_from_slice(buf.alg_name());
 
         Ok(Alg {
             alg_name,

--- a/src/nlas/alg_aead.rs
+++ b/src/nlas/alg_aead.rs
@@ -33,7 +33,7 @@ impl<T: AsRef<[u8]> + ?Sized> Parseable<AlgAeadBuffer<&T>> for AlgAead {
     fn parse(buf: &AlgAeadBuffer<&T>) -> Result<Self, DecodeError> {
         let mut alg_name: [u8; XFRM_ALG_AEAD_NAME_LEN] =
             [0; XFRM_ALG_AEAD_NAME_LEN];
-        alg_name.clone_from_slice(&buf.alg_name());
+        alg_name.clone_from_slice(buf.alg_name());
 
         Ok(AlgAead {
             alg_name,

--- a/src/nlas/alg_auth.rs
+++ b/src/nlas/alg_auth.rs
@@ -33,7 +33,7 @@ impl<T: AsRef<[u8]> + ?Sized> Parseable<AlgAuthBuffer<&T>> for AlgAuth {
     fn parse(buf: &AlgAuthBuffer<&T>) -> Result<Self, DecodeError> {
         let mut alg_name: [u8; XFRM_ALG_AUTH_NAME_LEN] =
             [0; XFRM_ALG_AUTH_NAME_LEN];
-        alg_name.clone_from_slice(&buf.alg_name());
+        alg_name.clone_from_slice(buf.alg_name());
 
         Ok(AlgAuth {
             alg_name,

--- a/src/nlas/mod.rs
+++ b/src/nlas/mod.rs
@@ -24,6 +24,7 @@ pub use replay::*;
 pub mod replay_esn;
 pub use replay_esn::*;
 
+#[allow(clippy::len_without_is_empty)]
 pub mod security_ctx;
 pub use security_ctx::*;
 
@@ -66,7 +67,8 @@ pub enum XfrmAttrs {
     EncapsulationTemplate(EncapTmpl),
     EncryptionAlg(Alg),
     EncryptionAlgAead(AlgAead),
-    EventTimeThreshold(u32), // replay event timer threshold (rate limit in ms)
+    EventTimeThreshold(u32), /* replay event timer threshold (rate limit in
+                              * ms) */
     ExtraFlags(u32),
     IfId(u32),
     KmAddress(UserKmAddress),
@@ -138,7 +140,6 @@ impl Nla for XfrmAttrs {
         }
     }
 
-    #[rustfmt::skip]
     fn emit_value(&self, buffer: &mut [u8]) {
         use self::XfrmAttrs::*;
         match *self {
@@ -162,7 +163,9 @@ impl Nla for XfrmAttrs {
             MarkVal(ref v) => NativeEndian::write_u32(buffer, *v),
             Migrate(ref v) => v.emit(buffer),
             OffloadDevice(ref v) => v.emit(buffer),
-            Pad() => /*ignore*/return,
+            Pad() =>
+                /* ignore */
+                {}
             PolicyInfo(ref v) => v.emit(buffer),
             PolicyType(ref v) => v.emit(buffer),
             Proto(ref v) => buffer[0] = *v,
@@ -174,20 +177,18 @@ impl Nla for XfrmAttrs {
             SrcAddr(ref v) => v.emit(buffer),
             Template(ref v) => {
                 let mut it_tmpl = v.iter();
-                let mut it_buf = buffer.chunks_exact_mut(XFRM_USER_TEMPLATE_LEN);
-
+                let mut it_buf =
+                    buffer.chunks_exact_mut(XFRM_USER_TEMPLATE_LEN);
                 loop {
-                    if let Some(tmpl) = it_tmpl.next() {
-                        if let Some(buf) = it_buf.next() {
-                            tmpl.emit(buf);
-                        } else {
-                            break;
-                        }
+                    if let (Some(tmpl), Some(buf)) =
+                        (it_tmpl.next(), it_buf.next())
+                    {
+                        tmpl.emit(buf);
                     } else {
                         break;
                     }
                 }
-            },
+            }
             TfcPadding(ref v) => NativeEndian::write_u32(buffer, *v),
             Unspec(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
 
@@ -354,9 +355,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for XfrmAttrs {
             ),
             XFRMA_TMPL => {
                 let mut tmpls: Vec<UserTemplate> = vec![];
-                let mut it = payload.chunks_exact(XFRM_USER_TEMPLATE_LEN);
+                let it = payload.chunks_exact(XFRM_USER_TEMPLATE_LEN);
 
-                while let Some(t) = it.next() {
+                for t in it {
                     let tmpl =
                         UserTemplate::parse(&UserTemplateBuffer::new(&t))
                             .context("invalid XFRMA_TMPL")?;
@@ -371,7 +372,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for XfrmAttrs {
 
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/nlas/security_ctx.rs
+++ b/src/nlas/security_ctx.rs
@@ -68,13 +68,13 @@ impl Emitable for SecurityCtx {
 }
 
 impl SecurityCtx {
-    pub fn context(&mut self, secctx: &Vec<u8>) {
+    pub fn context(&mut self, secctx: &[u8]) {
         // The kernel limits the length of the security context
         // string to the page size, which is commonly 4096.
         // iproute2 limits it to 256 when parsing from the cli.
         // Keeping it at 256 should be plenty, but if it needs to
         // be a little more generous, it can be raised.
-        let mut ctx_str = secctx.clone();
+        let mut ctx_str = secctx.to_vec();
         ctx_str.truncate(256);
         self.ctx_len = ctx_str.len() as u16;
         self.ctx_str = ctx_str;

--- a/src/policy/spdinfo/message.rs
+++ b/src/policy/spdinfo/message.rs
@@ -23,7 +23,7 @@ impl Emitable for NewSpdInfoMessage {
     fn emit(&self, buffer: &mut [u8]) {
         let mut buffer = NewSpdInfoMessageBuffer::new(buffer);
         buffer.set_flags(self.flags);
-        self.nlas.as_slice().emit(&mut buffer.attributes_mut());
+        self.nlas.as_slice().emit(buffer.attributes_mut());
     }
 }
 

--- a/src/policy/spdinfo/nlas/mod.rs
+++ b/src/policy/spdinfo/nlas/mod.rs
@@ -87,7 +87,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for SpdInfoAttrs {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/state/sadinfo/message.rs
+++ b/src/state/sadinfo/message.rs
@@ -23,7 +23,7 @@ impl Emitable for NewSadInfoMessage {
     fn emit(&self, buffer: &mut [u8]) {
         let mut buffer = NewSadInfoMessageBuffer::new(buffer);
         buffer.set_flags(self.flags);
-        self.nlas.as_slice().emit(&mut buffer.attributes_mut());
+        self.nlas.as_slice().emit(buffer.attributes_mut());
     }
 }
 

--- a/src/state/sadinfo/nlas/mod.rs
+++ b/src/state/sadinfo/nlas/mod.rs
@@ -73,7 +73,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for SadInfoAttrs {
             ),
             kind => Other(
                 DefaultNla::parse(buf)
-                    .context(format!("unknown NLA type {}", kind))?,
+                    .context(format!("unknown NLA type {kind}"))?,
             ),
         })
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,11 +23,11 @@ fn parse_xfrm_pol_1() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P1_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::FlushPolicy(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -49,7 +49,7 @@ fn emit_xfrm_pol_1() {
     );
     packet.finalize();
     packet.serialize(&mut buf[..]);
-    println!("{:?}", packet);
+    println!("{packet:?}");
     assert_eq!(&buf[..], &P1_BYTES[..]);
 
     //send it out kernel netlink socket to perform the actual flush (needs to
@@ -62,11 +62,11 @@ fn parse_xfrm_pol_2() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P2_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::FlushPolicy(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -93,7 +93,7 @@ fn emit_xfrm_pol_2() {
     );
     packet.finalize();
     packet.serialize(&mut buf[..]);
-    println!("{:?}", packet);
+    println!("{packet:?}");
     assert_eq!(&buf[..], &P2_BYTES[..]);
 
     //send it out kernel netlink socket to perform the actual flush (needs to
@@ -106,7 +106,7 @@ fn parse_xfrm_pol_3() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P3_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::AddPolicy(xm)) => {
@@ -327,7 +327,7 @@ fn emit_xfrm_pol_3() {
     );
     packet.finalize();
     packet.serialize(&mut buf[..]);
-    println!("{:?}", packet);
+    println!("{packet:?}");
     assert_eq!(&buf[..], &P3_BYTES[..]);
 
     //netlink_send_recv(&buf[..]);
@@ -338,7 +338,7 @@ fn parse_emit_xfrm_pol_4() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P4_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -346,7 +346,7 @@ fn parse_emit_xfrm_pol_4() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::UpdatePolicy(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -359,7 +359,7 @@ fn parse_xfrm_pol_5() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P5_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::AddPolicy(xm)) => {
@@ -566,7 +566,7 @@ fn emit_xfrm_pol_5() {
     );
     packet.finalize();
     packet.serialize(&mut buf[..]);
-    println!("{:?}", packet);
+    println!("{packet:?}");
     assert_eq!(&buf[..], &P5_BYTES[..]);
 
     //netlink_send_recv(&buf[..]);
@@ -577,7 +577,7 @@ fn parse_emit_xfrm_pol_6() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P6_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -585,7 +585,7 @@ fn parse_emit_xfrm_pol_6() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::DeletePolicy(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -600,7 +600,7 @@ fn parse_emit_xfrm_pol_7() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P7_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -608,7 +608,7 @@ fn parse_emit_xfrm_pol_7() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::GetPolicy(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -623,7 +623,7 @@ fn parse_emit_xfrm_pol_8() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P8_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -631,7 +631,7 @@ fn parse_emit_xfrm_pol_8() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::AddPolicy(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -646,7 +646,7 @@ fn parse_emit_xfrm_pol_9() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P9_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -654,7 +654,7 @@ fn parse_emit_xfrm_pol_9() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::GetSpdInfo(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -669,7 +669,7 @@ fn parse_emit_xfrm_pol_10() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P10_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -677,7 +677,7 @@ fn parse_emit_xfrm_pol_10() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::NewSpdInfo(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
 
             // iterate attributes
             for attr in xm.nlas.iter() {
@@ -717,7 +717,7 @@ fn parse_emit_xfrm_pol_11() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P11_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -725,7 +725,7 @@ fn parse_emit_xfrm_pol_11() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::GetPolicyDefault(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -740,7 +740,7 @@ fn parse_emit_xfrm_pol_12() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P12_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; P12_BYTES.len()]; // the sample packet has one extra byte of padding that isn't parsed
                                             //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -748,7 +748,7 @@ fn parse_emit_xfrm_pol_12() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::GetPolicyDefault(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -763,7 +763,7 @@ fn parse_emit_xfrm_pol_13() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P13_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -771,7 +771,7 @@ fn parse_emit_xfrm_pol_13() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::SetPolicyDefault(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -786,7 +786,7 @@ fn parse_emit_xfrm_pol_14() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&P14_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -794,7 +794,7 @@ fn parse_emit_xfrm_pol_14() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::AddPolicy(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -809,7 +809,7 @@ fn parse_emit_xfrm_st_1() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S1_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -817,7 +817,7 @@ fn parse_emit_xfrm_st_1() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::AddSa(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -832,7 +832,7 @@ fn parse_emit_xfrm_st_2() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S2_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -840,7 +840,7 @@ fn parse_emit_xfrm_st_2() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::UpdateSa(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -855,7 +855,7 @@ fn parse_emit_xfrm_st_3() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S3_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -863,7 +863,7 @@ fn parse_emit_xfrm_st_3() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::GetSa(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -878,7 +878,7 @@ fn parse_emit_xfrm_st_4() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S4_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -886,7 +886,7 @@ fn parse_emit_xfrm_st_4() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::AddSa(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -901,7 +901,7 @@ fn parse_emit_xfrm_st_5() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S5_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -909,7 +909,7 @@ fn parse_emit_xfrm_st_5() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::DeleteSa(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -924,7 +924,7 @@ fn parse_emit_xfrm_st_6() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S6_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -932,7 +932,7 @@ fn parse_emit_xfrm_st_6() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::FlushSa(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -947,7 +947,7 @@ fn parse_emit_xfrm_st_7() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S7_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -955,7 +955,7 @@ fn parse_emit_xfrm_st_7() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::GetSadInfo(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -970,7 +970,7 @@ fn parse_emit_xfrm_st_8() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S8_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -978,13 +978,13 @@ fn parse_emit_xfrm_st_8() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::NewSadInfo(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
             // iterate attributes
             for attr in xm.nlas.iter() {
                 match attr {
                     SadCount(si) => assert_eq!(*si, 1),
                     SadHInfo(si) => {
-                        println!("{:?}", si);
+                        println!("{si:?}");
                         assert_eq!(si.sadhcnt, 8);
                         assert_eq!(si.sadhmcnt, 1048576);
                     }
@@ -1007,7 +1007,7 @@ fn parse_emit_xfrm_st_9() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S9_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -1015,7 +1015,7 @@ fn parse_emit_xfrm_st_9() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::AllocSpi(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -1030,7 +1030,7 @@ fn parse_emit_xfrm_st_10() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&S10_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -1038,7 +1038,7 @@ fn parse_emit_xfrm_st_10() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::AddSa(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -1053,7 +1053,7 @@ fn parse_emit_xfrm_mon_1() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&M1_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -1061,7 +1061,7 @@ fn parse_emit_xfrm_mon_1() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::Expire(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -1076,7 +1076,7 @@ fn parse_emit_xfrm_mon_2() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&M2_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -1084,7 +1084,7 @@ fn parse_emit_xfrm_mon_2() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::PolicyExpire(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -1099,7 +1099,7 @@ fn parse_emit_xfrm_mon_3() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&M3_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -1107,7 +1107,7 @@ fn parse_emit_xfrm_mon_3() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::Acquire(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -1149,7 +1149,7 @@ fn emit_xfrm_mon_4() {
     );
     packet.finalize();
     packet.serialize(&mut buf[..]);
-    println!("{:?}", packet);
+    println!("{packet:?}");
     assert_eq!(&buf[..packet.buffer_len()], &M4_BYTES[..]);
 
     //netlink_send_recv(&buf[..packet.buffer_len()]);
@@ -1160,7 +1160,7 @@ fn parse_emit_xfrm_mon_4() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&M4_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -1168,7 +1168,7 @@ fn parse_emit_xfrm_mon_4() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::GetAsyncEvent(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -1183,7 +1183,7 @@ fn parse_emit_xfrm_mon_5() {
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&M5_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     let mut buf = vec![0; deserialized_packet.buffer_len()];
     //reserialize
     deserialized_packet.serialize(&mut buf[..]);
@@ -1191,7 +1191,7 @@ fn parse_emit_xfrm_mon_5() {
 
     match deserialized_packet.into_parts().1 {
         NetlinkPayload::InnerMessage(XfrmMessage::NewAsyncEvent(xm)) => {
-            println!("{:?}", xm);
+            println!("{xm:?}");
         }
         _ => {
             panic!("unhandled NetlinkPayload variant");
@@ -1239,13 +1239,13 @@ fn emit_parse_xfrm_mon_6() {
         NetlinkMessage::new(nl_hdr, XfrmMessage::Report(report_payload).into());
     packet.finalize();
     packet.serialize(&mut buf[..]);
-    println!("{:?}", packet);
+    println!("{packet:?}");
     assert_eq!(&buf[..packet.buffer_len()], &M6_BYTES[..]);
 
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&M6_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     assert_eq!(packet, deserialized_packet);
 
     //netlink_send_recv(&buf[..packet.buffer_len()]);
@@ -1286,13 +1286,13 @@ fn emit_parse_xfrm_mon_7() {
     );
     packet.finalize();
     packet.serialize(&mut buf[..]);
-    println!("{:?}", packet);
+    println!("{packet:?}");
     assert_eq!(&buf[..packet.buffer_len()], &M7_BYTES[..]);
 
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&M7_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     assert_eq!(packet, deserialized_packet);
 
     //netlink_send_recv(&buf[..packet.buffer_len()]);
@@ -1322,13 +1322,13 @@ fn emit_parse_xfrm_mon_8() {
     );
     packet.finalize();
     packet.serialize(&mut buf[..]);
-    println!("{:?}", packet);
+    println!("{packet:?}");
     assert_eq!(&buf[..packet.buffer_len()], &M8_BYTES[..]);
 
     let deserialized_packet =
         NetlinkMessage::<XfrmMessage>::deserialize(&M8_BYTES)
             .expect("Failed to deserialize message");
-    println!("{:?}", deserialized_packet);
+    println!("{deserialized_packet:?}");
     assert_eq!(packet, deserialized_packet);
 
     //netlink_send_recv(&buf[..packet.buffer_len()]);
@@ -1342,7 +1342,7 @@ fn netlink_send_recv(pkt: &[u8]) {
     // address is for the kernel
     let kernel_addr = SocketAddr::new(0, 0);
     // send the message to the kernel
-    let n_sent = socket.send_to(&pkt[..], &kernel_addr, 0).unwrap();
+    let n_sent = socket.send_to(pkt, &kernel_addr, 0).unwrap();
     assert_eq!(n_sent, pkt.len());
     // buffer for receiving the response
     let mut buf = vec![0; 4096];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,14 +3,15 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
+use netlink_packet_core::{NetlinkHeader, NetlinkMessage, NetlinkPayload};
+
 use crate::{
     constants::*, policy::FlushMessage, policy::ModifyMessage, Address,
     AsyncEventId, EncapTmpl, GetAsyncEventMessage, Id, Lifetime,
-    LifetimeConfig, MappingMessage, Mark, MigrateMessage, NetlinkHeader,
-    NetlinkMessage, ReportMessage, SadInfoAttrs::*, Selector, SpdInfoAttrs::*,
-    UserKmAddress, UserMapping, UserMigrate, UserPolicyId, UserPolicyInfo,
-    UserPolicyType, UserReport, UserSaId, UserTemplate, XfrmAttrs,
-    XfrmAttrs::*, XfrmMessage,
+    LifetimeConfig, MappingMessage, Mark, MigrateMessage, ReportMessage,
+    SadInfoAttrs::*, Selector, SpdInfoAttrs::*, UserKmAddress, UserMapping,
+    UserMigrate, UserPolicyId, UserPolicyInfo, UserPolicyType, UserReport,
+    UserSaId, UserTemplate, XfrmAttrs, XfrmAttrs::*, XfrmMessage,
 };
 
 use netlink_packet_core::*;
@@ -38,20 +39,21 @@ fn parse_xfrm_pol_1() {
 fn emit_xfrm_pol_1() {
     let mut buf = vec![0; P1_BYTES.len()];
 
-    let mut packet = NetlinkMessage {
-        header: NetlinkHeader {
-            sequence_number: 1650675114,
-            flags: NLM_F_REQUEST | NLM_F_ACK,
-            ..Default::default()
-        },
-        payload: XfrmMessage::FlushPolicy(FlushMessage::default()).into(),
-    };
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.sequence_number = 1650675114;
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+    let mut packet = NetlinkMessage::new(
+        nl_hdr,
+        XfrmMessage::FlushPolicy(FlushMessage::default()).into(),
+    );
     packet.finalize();
     packet.serialize(&mut buf[..]);
     println!("{:?}", packet);
     assert_eq!(&buf[..], &P1_BYTES[..]);
 
-    //send it out kernel netlink socket to perform the actual flush (needs to be root)
+    //send it out kernel netlink socket to perform the actual flush (needs to
+    // be root)
     netlink_send_recv(&buf[..]);
 }
 
@@ -81,20 +83,21 @@ fn emit_xfrm_pol_2() {
             ..Default::default()
         })],
     };
-    let mut packet = NetlinkMessage {
-        header: NetlinkHeader {
-            sequence_number: 1650861160,
-            flags: NLM_F_REQUEST | NLM_F_ACK,
-            ..Default::default()
-        },
-        payload: XfrmMessage::FlushPolicy(flush_payload).into(),
-    };
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.sequence_number = 1650861160;
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+    let mut packet = NetlinkMessage::new(
+        nl_hdr,
+        XfrmMessage::FlushPolicy(flush_payload).into(),
+    );
     packet.finalize();
     packet.serialize(&mut buf[..]);
     println!("{:?}", packet);
     assert_eq!(&buf[..], &P2_BYTES[..]);
 
-    //send it out kernel netlink socket to perform the actual flush (needs to be root)
+    //send it out kernel netlink socket to perform the actual flush (needs to
+    // be root)
     netlink_send_recv(&buf[..]);
 }
 
@@ -314,14 +317,14 @@ fn emit_xfrm_pol_3() {
             XfrmAttrs::IfId(5),
         ],
     };
-    let mut packet = NetlinkMessage {
-        header: NetlinkHeader {
-            sequence_number: 1652078034,
-            flags: NLM_F_REQUEST | NLM_F_ACK,
-            ..Default::default()
-        },
-        payload: XfrmMessage::AddPolicy(modify_payload).into(),
-    };
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.sequence_number = 1652078034;
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+    let mut packet = NetlinkMessage::new(
+        nl_hdr,
+        XfrmMessage::AddPolicy(modify_payload).into(),
+    );
     packet.finalize();
     packet.serialize(&mut buf[..]);
     println!("{:?}", packet);
@@ -553,14 +556,14 @@ fn emit_xfrm_pol_5() {
             XfrmAttrs::IfId(5),
         ],
     };
-    let mut packet = NetlinkMessage {
-        header: NetlinkHeader {
-            sequence_number: 1658818497,
-            flags: NLM_F_REQUEST | NLM_F_ACK,
-            ..Default::default()
-        },
-        payload: XfrmMessage::AddPolicy(modify_payload).into(),
-    };
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.sequence_number = 1658818497;
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+    let mut packet = NetlinkMessage::new(
+        nl_hdr,
+        XfrmMessage::AddPolicy(modify_payload).into(),
+    );
     packet.finalize();
     packet.serialize(&mut buf[..]);
     println!("{:?}", packet);
@@ -1136,14 +1139,14 @@ fn emit_xfrm_mon_4() {
         },
     };
 
-    let mut packet = NetlinkMessage {
-        header: NetlinkHeader {
-            sequence_number: 0,
-            flags: NLM_F_REQUEST | NLM_F_ACK,
-            ..Default::default()
-        },
-        payload: XfrmMessage::GetAsyncEvent(get_async_payload).into(),
-    };
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.sequence_number = 0;
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+    let mut packet = NetlinkMessage::new(
+        nl_hdr,
+        XfrmMessage::GetAsyncEvent(get_async_payload).into(),
+    );
     packet.finalize();
     packet.serialize(&mut buf[..]);
     println!("{:?}", packet);
@@ -1228,15 +1231,12 @@ fn emit_parse_xfrm_mon_6() {
             &Ipv4Addr::from_str("192.168.1.1").unwrap(),
         ))],
     };
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.sequence_number = 0;
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_ACK;
 
-    let mut packet = NetlinkMessage {
-        header: NetlinkHeader {
-            sequence_number: 0,
-            flags: NLM_F_REQUEST | NLM_F_ACK,
-            ..Default::default()
-        },
-        payload: XfrmMessage::Report(report_payload).into(),
-    };
+    let mut packet =
+        NetlinkMessage::new(nl_hdr, XfrmMessage::Report(report_payload).into());
     packet.finalize();
     packet.serialize(&mut buf[..]);
     println!("{:?}", packet);
@@ -1276,15 +1276,14 @@ fn emit_parse_xfrm_mon_7() {
             new_sport: 20007,
         },
     };
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.sequence_number = 0;
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_ACK;
 
-    let mut packet = NetlinkMessage {
-        header: NetlinkHeader {
-            sequence_number: 0,
-            flags: NLM_F_REQUEST | NLM_F_ACK,
-            ..Default::default()
-        },
-        payload: XfrmMessage::Mapping(mapping_payload).into(),
-    };
+    let mut packet = NetlinkMessage::new(
+        nl_hdr,
+        XfrmMessage::Mapping(mapping_payload).into(),
+    );
     packet.finalize();
     packet.serialize(&mut buf[..]);
     println!("{:?}", packet);
@@ -1313,14 +1312,14 @@ fn emit_parse_xfrm_mon_8() {
         ],
     };
 
-    let mut packet = NetlinkMessage {
-        header: NetlinkHeader {
-            sequence_number: 0,
-            flags: NLM_F_REQUEST | NLM_F_ACK,
-            ..Default::default()
-        },
-        payload: XfrmMessage::Migrate(migrate_payload).into(),
-    };
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.sequence_number = 0;
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+    let mut packet = NetlinkMessage::new(
+        nl_hdr,
+        XfrmMessage::Migrate(migrate_payload).into(),
+    );
     packet.finalize();
     packet.serialize(&mut buf[..]);
     println!("{:?}", packet);
@@ -1339,7 +1338,8 @@ fn emit_parse_xfrm_mon_8() {
 fn netlink_send_recv(pkt: &[u8]) {
     // open a new socket for the NETLINK_XFRM subsystem
     let socket = Socket::new(NETLINK_XFRM).unwrap();
-    // address of the remote peer we'll send a message to. This particular address is for the kernel
+    // address of the remote peer we'll send a message to. This particular
+    // address is for the kernel
     let kernel_addr = SocketAddr::new(0, 0);
     // send the message to the kernel
     let n_sent = socket.send_to(&pkt[..], &kernel_addr, 0).unwrap();


### PR DESCRIPTION
Removed these reexports:
   * `netlink-packet-xfrm::ErrorMessage`
   * `netlink-packet-xfrm::NetlinkBuffer`
   * `netlink-packet-xfrm::NetlinkHeader`
   * `netlink-packet-xfrm::NetlinkMessage`
   * `netlink-packet-xfrm::NetlinkPayload`

Use latest rust-netlink crates