### PR TITLE
New release 0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,15 @@
+# Changelog
+## [0.2.0] - 2023-01-29
+### Breaking changes
+ - Removed the reexports. (8d3f0d2)
+    * `netlink-packet-xfrm::ErrorMessage`
+    * `netlink-packet-xfrm::NetlinkBuffer`
+    * `netlink-packet-xfrm::NetlinkHeader`
+    * `netlink-packet-xfrm::NetlinkMessage`
+    * `netlink-packet-xfrm::NetlinkPayload`
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-xfrm"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Scott Zuk <zooknotic@proton.me>"]
 edition = "2018"
 homepage = "https://github.com/rust-netlink/netlink-packet-xfrm"


### PR DESCRIPTION
=== Breaking changes
 - Removed the reexports. (8d3f0d2)
    * `netlink-packet-xfrm::ErrorMessage`
    * `netlink-packet-xfrm::NetlinkBuffer`
    * `netlink-packet-xfrm::NetlinkHeader`
    * `netlink-packet-xfrm::NetlinkMessage`
    * `netlink-packet-xfrm::NetlinkPayload`

=== New features
 - N/A

=== Bug fixes
 - N/A