### PR TITLE
Serde Debugability netlink-packet-xfrm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,13 @@ byteorder = "1.4.2"
 libc= "0.2.86"
 netlink-packet-core = { version = "0.5.0" }
 netlink-packet-utils = { version = "0.5.2" }
+serde = { version = "1", features = ["derive"], optional = true }
+serde-big-array = { version ="0.5.1", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
 netlink-proto = { version = "0.11.1" }
 netlink-sys = { version = "0.8.4" }
+
+[features]
+serde = ["dep:serde", "dep:serde-big-array", "netlink-packet-utils/serde"]

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
@@ -7,6 +9,7 @@ use netlink_packet_utils::{buffer, traits::*, DecodeError};
 pub const XFRM_ADDRESS_LEN: usize = 16;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Address {
     // Xfrm netlink API simply uses a 16 byte buffer for both IPv4 & IPv6
     // addresses and unfortunately doesn't always pair it with a family type.

--- a/src/async_event_id.rs
+++ b/src/async_event_id.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -12,6 +14,7 @@ use crate::{
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AsyncEventId {
     pub sa_id: UserSaId,
     pub saddr: Address,

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{Address, AddressBuffer, XFRM_ADDRESS_LEN};
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Id {
     pub daddr: Address,
     pub spi: u32, // big-endian

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::XFRM_INF;
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
@@ -7,6 +10,7 @@ use netlink_packet_utils::{buffer, traits::*, DecodeError};
 // Lifetime config
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LifetimeConfig {
     pub soft_byte_limit: u64,
     pub hard_byte_limit: u64,
@@ -82,6 +86,7 @@ impl Emitable for LifetimeConfig {
 // Lifetime curent
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Lifetime {
     pub bytes: u64,
     pub packets: u64,

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{
     constants::*,
     monitor::{
@@ -26,6 +29,7 @@ use netlink_packet_core::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum XfrmMessage {
     AddPolicy(PolicyModifyMessage),
     DeletePolicy(PolicyDelGetMessage),

--- a/src/monitor/acquire/message.rs
+++ b/src/monitor/acquire/message.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{AcquireMessageBuffer, UserAcquire, UserAcquireBuffer, XfrmAttrs};
 
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AcquireMessage {
     pub acquire: UserAcquire,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/monitor/expire/message.rs
+++ b/src/monitor/expire/message.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{ExpireMessageBuffer, UserExpire, UserExpireBuffer};
 
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExpireMessage {
     pub expire: UserExpire,
 }

--- a/src/monitor/get_async_event/message.rs
+++ b/src/monitor/get_async_event/message.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{AsyncEventId, AsyncEventIdBuffer, GetAsyncEventMessageBuffer};
 
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetAsyncEventMessage {
     pub id: AsyncEventId,
 }

--- a/src/monitor/mapping/message.rs
+++ b/src/monitor/mapping/message.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{MappingMessageBuffer, UserMapping, UserMappingBuffer};
 
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MappingMessage {
     pub map: UserMapping,
 }

--- a/src/monitor/migrate/message.rs
+++ b/src/monitor/migrate/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     MigrateMessageBuffer, UserPolicyId, UserPolicyIdBuffer, XfrmAttrs,
@@ -9,6 +11,7 @@ use crate::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MigrateMessage {
     pub user_policy_id: UserPolicyId,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/monitor/new_async_event/message.rs
+++ b/src/monitor/new_async_event/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AsyncEventId, AsyncEventIdBuffer, NewAsyncEventMessageBuffer, XfrmAttrs,
@@ -9,6 +11,7 @@ use crate::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NewAsyncEventMessage {
     pub id: AsyncEventId,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/monitor/polexpire/message.rs
+++ b/src/monitor/polexpire/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     PolicyExpireMessageBuffer, UserPolicyExpire, UserPolicyExpireBuffer,
@@ -10,6 +12,7 @@ use crate::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PolicyExpireMessage {
     pub expire: UserPolicyExpire,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/monitor/report/message.rs
+++ b/src/monitor/report/message.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{ReportMessageBuffer, UserReport, UserReportBuffer, XfrmAttrs};
 
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ReportMessage {
     pub report: UserReport,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/nlas/address_filter.rs
+++ b/src/nlas/address_filter.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 use std::net::IpAddr;
@@ -14,6 +16,7 @@ use crate::{
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AddressFilter {
     pub saddr: Address,
     pub daddr: Address,

--- a/src/nlas/alg.rs
+++ b/src/nlas/alg.rs
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use {
+    serde::{Deserialize, Serialize},
+    serde_big_array::BigArray,
+};
+
 use core::ops::Range;
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
@@ -7,7 +13,9 @@ use netlink_packet_utils::{buffer, traits::*, DecodeError};
 pub const XFRM_ALG_NAME_LEN: usize = 64;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Alg {
+    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
     pub alg_name: [u8; XFRM_ALG_NAME_LEN],
     pub alg_key_len: u32,
     pub alg_key: Vec<u8>,

--- a/src/nlas/alg_aead.rs
+++ b/src/nlas/alg_aead.rs
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use {
+    serde::{Deserialize, Serialize},
+    serde_big_array::BigArray,
+};
+
 use core::ops::Range;
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
@@ -7,7 +13,9 @@ use netlink_packet_utils::{buffer, traits::*, DecodeError};
 pub const XFRM_ALG_AEAD_NAME_LEN: usize = 64;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AlgAead {
+    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
     pub alg_name: [u8; XFRM_ALG_AEAD_NAME_LEN],
     pub alg_key_len: u32,
     pub alg_icv_len: u32,

--- a/src/nlas/alg_auth.rs
+++ b/src/nlas/alg_auth.rs
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use {
+    serde::{Deserialize, Serialize},
+    serde_big_array::BigArray,
+};
+
 use core::ops::Range;
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
@@ -7,7 +13,9 @@ use netlink_packet_utils::{buffer, traits::*, DecodeError};
 pub const XFRM_ALG_AUTH_NAME_LEN: usize = 64;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AlgAuth {
+    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
     pub alg_name: [u8; XFRM_ALG_AUTH_NAME_LEN],
     pub alg_key_len: u32,
     pub alg_trunc_len: u32,

--- a/src/nlas/encap_tmpl.rs
+++ b/src/nlas/encap_tmpl.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -9,6 +11,7 @@ use crate::{Address, AddressBuffer, XFRM_ADDRESS_LEN};
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EncapTmpl {
     pub encap_type: u16,
     pub encap_sport: u16, // big-endian

--- a/src/nlas/mark.rs
+++ b/src/nlas/mark.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Mark {
     pub value: u32,
     pub mask: u32,

--- a/src/nlas/mod.rs
+++ b/src/nlas/mod.rs
@@ -42,6 +42,8 @@ pub use user_template::*;
 
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::mem::size_of;
 
 use crate::{
@@ -58,6 +60,7 @@ use netlink_packet_utils::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum XfrmAttrs {
     AddressFilter(address_filter::AddressFilter),
     AuthenticationAlg(Alg),

--- a/src/nlas/replay.rs
+++ b/src/nlas/replay.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Replay {
     pub oseq: u32,
     pub seq: u32,

--- a/src/nlas/replay_esn.rs
+++ b/src/nlas/replay_esn.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use byteorder::{ByteOrder, NativeEndian};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 pub const XFRM_REPLAY_ESN_LEN: usize = 24;
 
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ReplayEsn {
     pub bmp_len: u32,
     pub oseq: u32,

--- a/src/nlas/security_ctx.rs
+++ b/src/nlas/security_ctx.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 use crate::constants::*;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SecurityCtx {
     pub len: u16,
     pub exttype: u16,

--- a/src/nlas/user_kmaddress.rs
+++ b/src/nlas/user_kmaddress.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -9,6 +11,7 @@ use crate::{Address, AddressBuffer, XFRM_ADDRESS_LEN};
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserKmAddress {
     pub local: Address,
     pub remote: Address,

--- a/src/nlas/user_migrate.rs
+++ b/src/nlas/user_migrate.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -9,6 +11,8 @@ use crate::{Address, AddressBuffer, XFRM_ADDRESS_LEN};
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+
 pub struct UserMigrate {
     pub old_daddr: Address,
     pub old_saddr: Address,

--- a/src/nlas/user_offload.rs
+++ b/src/nlas/user_offload.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserOffloadDev {
     pub ifindex: i32, /* "int" in iproute2 */
     pub flags: u8,

--- a/src/nlas/user_template.rs
+++ b/src/nlas/user_template.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     constants::{AF_INET, AF_INET6},
@@ -12,6 +14,7 @@ use std::net::IpAddr;
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserTemplate {
     pub id: Id,
     pub family: u16,

--- a/src/policy/default/message.rs
+++ b/src/policy/default/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::policy::{DefaultMessageBuffer, POLICY_DEFAULT_HEADER_LEN};
 use crate::{UserPolicyDefault, UserPolicyDefaultBuffer};
@@ -8,6 +10,7 @@ use crate::{UserPolicyDefault, UserPolicyDefaultBuffer};
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DefaultMessage {
     pub user_policy: UserPolicyDefault,
 }

--- a/src/policy/delget/message.rs
+++ b/src/policy/delget/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     policy::DelGetMessageBuffer, UserPolicyId, UserPolicyIdBuffer, XfrmAttrs,
@@ -9,6 +11,7 @@ use crate::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DelGetMessage {
     pub user_policy_id: UserPolicyId,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/policy/flush/message.rs
+++ b/src/policy/flush/message.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{policy::FlushMessageBuffer, XfrmAttrs};
 
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FlushMessage {
     pub nlas: Vec<XfrmAttrs>,
 }

--- a/src/policy/modify/message.rs
+++ b/src/policy/modify/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     policy::ModifyMessageBuffer, UserPolicyInfo, UserPolicyInfoBuffer,
@@ -10,6 +12,7 @@ use crate::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ModifyMessage {
     pub user_policy_info: UserPolicyInfo,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/policy/spdinfo/message.rs
+++ b/src/policy/spdinfo/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::policy::{
     GetSpdInfoMessageBuffer, NewSpdInfoMessageBuffer, SpdInfoAttrs,
@@ -10,6 +12,7 @@ use crate::policy::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NewSpdInfoMessage {
     pub flags: u32,
     pub nlas: Vec<SpdInfoAttrs>,
@@ -56,6 +59,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<NewSpdInfoMessageBuffer<&'a T>>
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetSpdInfoMessage {
     pub flags: u32,
 }

--- a/src/policy/spdinfo/nlas/mod.rs
+++ b/src/policy/spdinfo/nlas/mod.rs
@@ -4,6 +4,8 @@ pub mod spd_info;
 pub use spd_info::*;
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::constants::*;
 
@@ -14,6 +16,7 @@ use netlink_packet_utils::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SpdInfoAttrs {
     Unspec(Vec<u8>),
     SpdInfo(spd_info::SpdInfo),

--- a/src/policy/spdinfo/nlas/spd_info.rs
+++ b/src/policy/spdinfo/nlas/spd_info.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SpdInfo {
     pub incnt: u32,
     pub outcnt: u32,
@@ -53,6 +57,7 @@ impl Emitable for SpdInfo {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SpdHInfo {
     pub spdhcnt: u32,
     pub spdhmcnt: u32,
@@ -87,6 +92,7 @@ impl Emitable for SpdHInfo {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SpdHThresh {
     pub lbits: u8,
     pub rbits: u8,

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 use std::net::IpAddr;
@@ -13,6 +15,7 @@ use crate::{
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Selector {
     pub daddr: Address,
     pub saddr: Address,

--- a/src/state/allocspi/message.rs
+++ b/src/state/allocspi/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::state::AllocSpiMessageBuffer;
 use crate::{UserSpiInfo, UserSpiInfoBuffer, XfrmAttrs};
@@ -8,6 +10,7 @@ use crate::{UserSpiInfo, UserSpiInfoBuffer, XfrmAttrs};
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AllocSpiMessage {
     pub spi_info: UserSpiInfo,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/state/delget/message.rs
+++ b/src/state/delget/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     state::{DelGetMessageBuffer, GetDumpMessageBuffer},
@@ -10,6 +12,7 @@ use crate::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DelGetMessage {
     pub user_sa_id: UserSaId,
     pub nlas: Vec<XfrmAttrs>,
@@ -56,6 +59,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<DelGetMessageBuffer<&'a T>>
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetDumpMessage {
     pub nlas: Vec<XfrmAttrs>,
 }

--- a/src/state/flush/message.rs
+++ b/src/state/flush/message.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::state::{FlushMessageBuffer, STATE_FLUSH_HEADER_LEN};
 
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FlushMessage {
     pub protocol: u8,
 }

--- a/src/state/modify/message.rs
+++ b/src/state/modify/message.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     state::ModifyMessageBuffer, UserSaInfo, UserSaInfoBuffer, XfrmAttrs,
@@ -9,6 +11,7 @@ use crate::{
 use netlink_packet_utils::{traits::*, DecodeError};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ModifyMessage {
     pub user_sa_info: UserSaInfo,
     pub nlas: Vec<XfrmAttrs>,

--- a/src/state/sadinfo/message.rs
+++ b/src/state/sadinfo/message.rs
@@ -8,8 +8,11 @@ use crate::state::{
 };
 
 use netlink_packet_utils::{traits::*, DecodeError};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NewSadInfoMessage {
     pub flags: u32,
     pub nlas: Vec<SadInfoAttrs>,
@@ -56,6 +59,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<NewSadInfoMessageBuffer<&'a T>>
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetSadInfoMessage {
     pub flags: u32,
 }

--- a/src/state/sadinfo/nlas/mod.rs
+++ b/src/state/sadinfo/nlas/mod.rs
@@ -5,6 +5,8 @@ pub use sad_info::*;
 
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::mem::size_of;
 
 use crate::constants::*;
@@ -17,6 +19,7 @@ use netlink_packet_utils::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SadInfoAttrs {
     Unspec(Vec<u8>),
     SadCount(u32),

--- a/src/state/sadinfo/nlas/sad_info.rs
+++ b/src/state/sadinfo/nlas/sad_info.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SadHInfo {
     pub sadhcnt: u32,
     pub sadhmcnt: u32,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Stats {
     pub replay_window: u32,
     pub replay: u32,

--- a/src/user_acquire.rs
+++ b/src/user_acquire.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -13,6 +15,7 @@ use crate::{
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserAcquire {
     pub id: Id,
     pub saddr: Address,

--- a/src/user_expire.rs
+++ b/src/user_expire.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -9,6 +11,7 @@ use crate::{UserSaInfo, UserSaInfoBuffer, XFRM_USER_SA_INFO_LEN};
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserExpire {
     pub state: UserSaInfo,
     pub hard: u8,

--- a/src/user_mapping.rs
+++ b/src/user_mapping.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -12,6 +14,7 @@ use crate::{
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserMapping {
     pub id: UserSaId,
     pub reqid: u32,

--- a/src/user_polexpire.rs
+++ b/src/user_polexpire.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -9,6 +11,7 @@ use crate::{UserPolicyInfo, UserPolicyInfoBuffer, XFRM_USER_POLICY_INFO_LEN};
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserPolicyExpire {
     pub pol: UserPolicyInfo,
     pub hard: u8,

--- a/src/user_policy_default.rs
+++ b/src/user_policy_default.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserPolicyDefault {
     pub input: u8,
     pub forward: u8,

--- a/src/user_policy_id.rs
+++ b/src/user_policy_id.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -9,6 +11,7 @@ use crate::{Selector, SelectorBuffer, XFRM_SELECTOR_LEN};
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserPolicyId {
     pub selector: Selector,
     pub index: u32,

--- a/src/user_policy_info.rs
+++ b/src/user_policy_info.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -13,6 +15,7 @@ use crate::{
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserPolicyInfo {
     pub selector: Selector,
     pub lifetime_cfg: LifetimeConfig,

--- a/src/user_policy_type.rs
+++ b/src/user_policy_type.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserPolicyType {
     pub ptype: u8,
     pub reserved1: u16,

--- a/src/user_report.rs
+++ b/src/user_report.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -9,6 +11,7 @@ use crate::{Selector, SelectorBuffer, XFRM_SELECTOR_LEN};
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserReport {
     pub proto: u8,
     pub selector: Selector,

--- a/src/user_sa_id.rs
+++ b/src/user_sa_id.rs
@@ -7,11 +7,14 @@ use crate::{
     Address, AddressBuffer, XFRM_ADDRESS_LEN,
 };
 use core::ops::Range;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserSaId {
     pub daddr: Address,
     pub spi: u32, // big-endian

--- a/src/user_sa_info.rs
+++ b/src/user_sa_info.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -15,6 +17,7 @@ use netlink_packet_utils::{buffer, traits::*, DecodeError};
 use std::net::IpAddr;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserSaInfo {
     pub selector: Selector,
     pub id: Id,

--- a/src/user_spi_info.rs
+++ b/src/user_spi_info.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use core::ops::Range;
 
@@ -12,6 +14,7 @@ use crate::{
 use netlink_packet_utils::{buffer, traits::*, DecodeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UserSpiInfo {
     pub info: UserSaInfo,
     pub min: u32,


### PR DESCRIPTION
Adds serde feature to derive ser/des functionality on each type. In conjunction **and dependent on** [netlink-packet-utils PR#9](https://github.com/rust-netlink/netlink-packet-utils/pull/9)